### PR TITLE
Add local.settings.json for local development

### DIFF
--- a/src/local.settings.json
+++ b/src/local.settings.json
@@ -1,0 +1,8 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
+    "TIMER_SCHEDULE": "*/30 * * * * *"
+  }
+}


### PR DESCRIPTION
## Summary

Adds `local.settings.json` with Azurite emulator settings and configurable timer schedule for local development. Matches sibling Python/TS timer repo pattern.

## What's included

`src/local.settings.json` with:
- `AzureWebJobsStorage: UseDevelopmentStorage=true` (Azurite emulator)
- `FUNCTIONS_WORKER_RUNTIME: dotnet-isolated`
- `TIMER_SCHEDULE: */30 * * * * *`

## Context

Tracked by Azure/azure-functions-templates — ensuring all manifest templates have `local.settings.json` for local development per review feedback on PR #1753.