### PR TITLE
Migrate from Application Insights to OpenTelemetry

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -9,12 +9,18 @@ var host = new HostBuilder()
     .ConfigureFunctionsWorkerDefaults()
     .ConfigureServices(services =>
     {
+#if DEBUG
         if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING")))
         {
             services.AddOpenTelemetry()
                 .UseFunctionsWorkerDefaults()
                 .UseAzureMonitorExporter();
         }
+#else
+        services.AddOpenTelemetry()
+            .UseFunctionsWorkerDefaults()
+            .UseAzureMonitorExporter();
+#endif
     })
     .Build();
 

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1,13 +1,17 @@
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Azure.Monitor.OpenTelemetry.Exporter;
+using Microsoft.Azure.Functions.Worker.OpenTelemetry;
+using OpenTelemetry;
 
 var host = new HostBuilder()
     .ConfigureFunctionsWorkerDefaults()
     .ConfigureServices(services =>
     {
-        services.AddApplicationInsightsTelemetryWorkerService();
-        services.ConfigureFunctionsApplicationInsights();
+        services.AddOpenTelemetry()
+            .UseFunctionsWorkerDefaults()
+            .UseAzureMonitorExporter();
     })
     .Build();
 

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -9,9 +9,12 @@ var host = new HostBuilder()
     .ConfigureFunctionsWorkerDefaults()
     .ConfigureServices(services =>
     {
-        services.AddOpenTelemetry()
-            .UseFunctionsWorkerDefaults()
-            .UseAzureMonitorExporter();
+        if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING")))
+        {
+            services.AddOpenTelemetry()
+                .UseFunctionsWorkerDefaults()
+                .UseAzureMonitorExporter();
+        }
     })
     .Build();
 

--- a/src/host.json
+++ b/src/host.json
@@ -1,5 +1,6 @@
 {
     "version": "2.0",
+    "telemetryMode": "OpenTelemetry",
     "logging": {
         "applicationInsights": {
             "samplingSettings": {

--- a/src/host.json
+++ b/src/host.json
@@ -1,13 +1,4 @@
 {
     "version": "2.0",
-    "telemetryMode": "OpenTelemetry",
-    "logging": {
-        "applicationInsights": {
-            "samplingSettings": {
-                "isEnabled": true,
-                "excludedTypes": "Request"
-            },
-            "enableLiveMetricsFilters": true
-        }
-    }
+    "telemetryMode": "OpenTelemetry"
 }

--- a/src/timer.csproj
+++ b/src/timer.csproj
@@ -11,9 +11,9 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.OpenTelemetry" Version="1.2.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.7.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.21.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/src/timer.csproj
+++ b/src/timer.csproj
@@ -8,14 +8,12 @@
     <UserSecretsId>09bd123b-3401-4507-b92c-0b283b95b537</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.OpenTelemetry" Version="1.2.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.7.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.21.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
-    <PackageReference
-      Include="Microsoft.Azure.Functions.Worker.ApplicationInsights"
-      Version="1.2.0"
-    />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">


### PR DESCRIPTION
## Purpose
* Migrate the sample from the Application Insights worker SDK to the OpenTelemetry approach for telemetry. Telemetry still flows to Application Insights via the Azure Monitor OpenTelemetry exporter.
* Mirrors the template change in [Azure/azure-functions-templates@1cc8df7](https://github.com/Azure/azure-functions-templates/commit/1cc8df7bb3807bad1641e44d604567a5f313814f).

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What to Check
* `csproj`: removed `Microsoft.ApplicationInsights.WorkerService` and `Microsoft.Azure.Functions.Worker.ApplicationInsights`; added `Microsoft.Azure.Functions.Worker.OpenTelemetry`, `OpenTelemetry.Extensions.Hosting`, and `Azure.Monitor.OpenTelemetry.Exporter`.
* `Program.cs`: replaced `AddApplicationInsightsTelemetryWorkerService` / `ConfigureFunctionsApplicationInsights` with `AddOpenTelemetry().UseFunctionsWorkerDefaults().UseAzureMonitorExporter()`.
* `host.json`: added `"telemetryMode": "OpenTelemetry"`.
* After deploying, telemetry continues to appear in the linked Application Insights resource.
